### PR TITLE
Fixed `browser-api/common/Makefile` (avoid the dependency error when directories creating)

### DIFF
--- a/browser-ext/login/Makefile
+++ b/browser-ext/login/Makefile
@@ -296,30 +296,30 @@ $(1):
 endef
 
 define COPY_RULE
-$(2): $(1) | $(dir $(2))
+$(2): $(1) | $(patsubst %/,%,$(dir $(2)))
 	@echo $(2)
 	@cp $(1) $(2)
 endef
 
 define EXTRACT_SCRIPTS_RULE
-$(2): $(1) | $(dir $(2))
+$(2): $(1) | $(patsubst %/,%,$(dir $(2)))
 	@$(SCRIPTS_EXTRACTOR) extract $(1) $(2)
 endef
 
 define CLOSURE_COMPILER_RULE
-$(2): $(1) | $(dir $(2))
+$(2): $(1) | $(patsubst %/,%,$(dir $(2)))
 	@echo $(2)
 	@$(CLOSURE) --js $(1) --js_output_file $(2) || exit $$?
 endef
 
 define MUSTACHE_RENDERER_RULE
-$(2): $(1) $(dir $(2)) $(BASE_TEMPLATE_FILES)
+$(2): $(1) $(patsubst %/,%,$(dir $(2))) $(BASE_TEMPLATE_FILES)
 	@echo $(2)
 	@NODE_PATH=../third_party node $(MUSTACHE_RENDERER) $(1) $(abspath $(2))
 endef
 
 define MUSTACHE_COMPILER_RULE
-$(2): $(1) $(dir $(2))
+$(2): $(1) $(patsubst %/,%,$(dir $(2)))
 	@echo $(2)
 	@$(MUSTACHE_COMPILER) $(1) > $(abspath $(2))
 endef


### PR DESCRIPTION
Fixed `browser-api/common/Makefile` (avoid the dependency error when directories creating)

Needed to remove the "/"(slash) directories name at the end.
> (NG) `.../browser-ext/login/build/chrome/release/`
> (OK) `.../browser-ext/login/build/chrome/release`

* BEFORE
~~~~
$ cd browser-ext/login
$ gmake -n
kzjs_srouces = ../api/build/node/lib/node_modules/keyczarjs/*.js
forge_srouces = ../api/build/node/lib/node_modules/keyczarjs/node_modules/node-forge/js/*.js
gmake: *** No rule to make target `/home/vagrant/mitro/browser-ext/login/build/chrome/release/', needed by `/home/vagrant/mitro/browser-ext/login/build/chrome/release/utils.js'.  Stop.

$ gmake --version
GNU Make 3.82
~~~~

* AFTER
~~~~
$ gmake -n
kzjs_srouces = ../api/build/node/lib/node_modules/keyczarjs/*.js
forge_srouces = ../api/build/node/lib/node_modules/keyczarjs/node_modules/node-forge/js/*.js
mkdir -p /home/vagrant/mitro/browser-ext/login/build/chrome/release
echo /home/vagrant/mitro/browser-ext/login/build/chrome/release/utils.js
...
~~~~
