### PR TITLE
Added option to override GOOGLE_CHROME detection; eg. for Chromium users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+binary_name

--- a/browser-ext/login/Makefile
+++ b/browser-ext/login/Makefile
@@ -10,7 +10,10 @@ CFX=$(BUILD_DIR)/../../third_party/firefox-addon-sdk/bin/cfx
 
 CLOSURE_STRICT_FLAGS=--language_in ECMASCRIPT5_STRICT --warning_level VERBOSE --compilation_level ADVANCED_OPTIMIZATIONS --externs externs_node.js --jscomp_error missingProperties --jscomp_error checkTypes --jscomp_error checkRegExp --jscomp_error accessControls --jscomp_error const --jscomp_error missingReturn
 
-ifeq ($(shell uname),Darwin)
+ifneq ($(shell cat binary_name),)
+  GOOGLE_CHROME=$(shell cat binary_name)
+  $(info Found binary_name file; Setting $$GOOGLE_CHROME to [${GOOGLE_CHROME}])
+else ifeq ($(shell uname),Darwin)
   GOOGLE_CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 else
   GOOGLE_CHROME=google-chrome

--- a/browser-ext/login/Makefile
+++ b/browser-ext/login/Makefile
@@ -299,30 +299,30 @@ $(1):
 endef
 
 define COPY_RULE
-$(2): $(1) | $(dir $(2))
+$(2): $(1) | $(patsubst %/,%,$(dir $(2)))
 	@echo $(2)
 	@cp $(1) $(2)
 endef
 
 define EXTRACT_SCRIPTS_RULE
-$(2): $(1) | $(dir $(2))
+$(2): $(1) | $(patsubst %/,%,$(dir $(2)))
 	@$(SCRIPTS_EXTRACTOR) extract $(1) $(2)
 endef
 
 define CLOSURE_COMPILER_RULE
-$(2): $(1) | $(dir $(2))
+$(2): $(1) | $(patsubst %/,%,$(dir $(2)))
 	@echo $(2)
 	@$(CLOSURE) --js $(1) --js_output_file $(2) || exit $$?
 endef
 
 define MUSTACHE_RENDERER_RULE
-$(2): $(1) $(dir $(2)) $(BASE_TEMPLATE_FILES)
+$(2): $(1) $(patsubst %/,%,$(dir $(2))) $(BASE_TEMPLATE_FILES)
 	@echo $(2)
 	@NODE_PATH=../third_party node $(MUSTACHE_RENDERER) $(1) $(abspath $(2))
 endef
 
 define MUSTACHE_COMPILER_RULE
-$(2): $(1) $(dir $(2))
+$(2): $(1) $(patsubst %/,%,$(dir $(2)))
 	@echo $(2)
 	@$(MUSTACHE_COMPILER) $(1) > $(abspath $(2))
 endef

--- a/browser-ext/login/frontend/static/js/popup.js
+++ b/browser-ext/login/frontend/static/js/popup.js
@@ -29,7 +29,10 @@ var INITIAL_FOCUS_REMOVE_TABINDEX_DELAY_MS = 750;
 // The popup width must match the width set in less/partials/variables.less
 // @total-popup-width: 290px;
 var POPUP_WIDTH = 290;
+// TODO: The popup has a width issue (). This is ONLY a temporary fix.
+var POPUP_TEMP_WIDTHFIX = 7;
 var SERVICES_PATH = 'secrets.html';
+
 
 // Safari does NOT reload the popup automatically when it's pressed.  this causes all kinds of strange issues to happen.
 // However, safari.application is not defined when the popup is loaded in a "normal" tab.
@@ -83,7 +86,7 @@ var updateLoginState = function () {
       }
       helper.tabs.create({url: helper.getURL('html/change-password.html' + hash)});
     } else {
-      if (($(window).width() > POPUP_WIDTH+7) && debugMode === false) { // Check to see if this in browser window, not popup
+      if (($(window).width() > POPUP_WIDTH+POPUP_TEMP_WIDTHFIX) && debugMode === false) { // Check to see if this in browser window, not popup
          // Redirect to services page if user is logged in and this is not inside the popup
         helper.setLocation(SERVICES_PATH);
       } else {
@@ -239,7 +242,7 @@ $(document).ready(function() {
   var $signUpBtn = $loggedOutPaneEl.find('.sign-up');
   var $remindAlertEl = $loginFormEl.find('#remind-alert');
 
-  if (($(window).width() > POPUP_WIDTH+7) && debugMode === false) {
+  if (($(window).width() > POPUP_WIDTH+POPUP_TEMP_WIDTHFIX) && debugMode === false) {
     // change the width of the wrap container to be the full size of the screen
     $wrapEl.addClass('web-wrap');
     $htmlEl.addClass('web');

--- a/browser-ext/login/frontend/static/js/popup.js
+++ b/browser-ext/login/frontend/static/js/popup.js
@@ -83,7 +83,7 @@ var updateLoginState = function () {
       }
       helper.tabs.create({url: helper.getURL('html/change-password.html' + hash)});
     } else {
-      if (($(window).width() > POPUP_WIDTH) && debugMode === false) { // Check to see if this in browser window, not popup
+      if (($(window).width() > POPUP_WIDTH+7) && debugMode === false) { // Check to see if this in browser window, not popup
          // Redirect to services page if user is logged in and this is not inside the popup
         helper.setLocation(SERVICES_PATH);
       } else {
@@ -239,7 +239,7 @@ $(document).ready(function() {
   var $signUpBtn = $loggedOutPaneEl.find('.sign-up');
   var $remindAlertEl = $loginFormEl.find('#remind-alert');
 
-  if (($(window).width() > POPUP_WIDTH) && debugMode === false) {
+  if (($(window).width() > POPUP_WIDTH+7) && debugMode === false) {
     // change the width of the wrap container to be the full size of the screen
     $wrapEl.addClass('web-wrap');
     $htmlEl.addClass('web');


### PR DESCRIPTION
This is useful for people who's binary is not google-chrome, eg. chromium users, or users of ArchLinux
(there GOOGLE_CHROME should be "google-chrome-stable").